### PR TITLE
New account fields

### DIFF
--- a/lib/corepro/account.rb
+++ b/lib/corepro/account.rb
@@ -17,6 +17,13 @@ module CorePro
     attr_accessor :accountNumberMasked
     attr_accessor :legalName1
     attr_accessor :legalName2
+    attr_accessor :externalProgramTag
+    attr_accessor :interestTransferFkId
+    attr_accessor :productId
+
+    # link related
+    attr_accessor :sourceLinks
+    attr_accessor :targetLinks
 
     # state related
     attr_accessor :status
@@ -28,6 +35,7 @@ module CorePro
     attr_accessor :isLocked
     attr_accessor :lockReasonTypeCode
     attr_accessor :lastModifiedDate
+    attr_accessor :globalAccountAccessEnabled
 
     # goal related
     attr_accessor :targetAmount
@@ -36,12 +44,14 @@ module CorePro
     attr_accessor :targetMetPercent
     attr_accessor :category
     attr_accessor :subCategory
+    attr_accessor :maturityTypeCode
 
     # balance related
     attr_accessor :availableBalance
     attr_accessor :accountBalance
     attr_accessor :pendingBalance
     attr_accessor :balanceLastModifiedDate
+    attr_accessor :regDWithdrawalCount
 
     # recurring deposit related
     attr_accessor :recurringContributionType

--- a/lib/corepro/account.rb
+++ b/lib/corepro/account.rb
@@ -25,6 +25,8 @@ module CorePro
     attr_accessor :closedDate
     attr_accessor :isPrimary
     attr_accessor :isCloseable
+    attr_accessor :isLocked
+    attr_accessor :lockReasonTypeCode
     attr_accessor :lastModifiedDate
 
     # goal related

--- a/lib/corepro/version.rb
+++ b/lib/corepro/version.rb
@@ -1,4 +1,4 @@
 #!/usr/bin/ruby -w
 module CorePro
-  VERSION = '1.0.1'
+  VERSION = '1.0.2'
 end


### PR DESCRIPTION
New fields have been added to the Corepro Account that are missing attr_accessors in the gem's Account object. This PR is to add these missing fields on the Account object.